### PR TITLE
v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## [1.0.2] - 2021-01-11
+### Fixed
+- Using `Initialize()` method instead of `[OnInspectorInit]` attribute
+
 ## [1.0.1] - 2021-01-08
 ### Changed
 - Incorrect display of package name for openupm cli install method
 
 ## [1.0.0] - 2021-01-07
-
 ### Added
 - Initial version

--- a/Editor/ReflectiveGeneratorWindow.cs
+++ b/Editor/ReflectiveGeneratorWindow.cs
@@ -47,8 +47,7 @@ namespace TNRD.Reflectives
         [ValueDropdown(nameof(GetTypes), IsUniqueList = true)]
         private List<Type> selectedTypes = new List<Type>();
 
-        [OnInspectorInit]
-        private void OnInspectorInit()
+        protected override void Initialize()
         {
             types = AppDomain.CurrentDomain.GetAssemblies()
                 .Where(x => x.GetTypes().Any())

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "net.tnrd.reflectives",
   "displayName": "Reflectives",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "unity": "2019.1",
   "keywords": [
     "reflection",


### PR DESCRIPTION
### Fixed
- Using `Initialize()` method instead of `[OnInspectorInit]` attribute